### PR TITLE
Fix missing BytesIO import

### DIFF
--- a/duetwebapi/api/base.py
+++ b/duetwebapi/api/base.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Union
-from io import StringIO, TextIOWrapper
+from io import StringIO, TextIOWrapper, BytesIO
 import requests
 import os
 import logging


### PR DESCRIPTION
Was getting import error after type hint updates:

```
... /duetwebapi/api/base.py", line 47, in DuetAPI
    def upload_file(self, file: Union[str, bytes, StringIO, TextIOWrapper, BytesIO], filename: str, directory: str = 'gcodes') -> Dict:
NameError: name 'BytesIO' is not defined
```